### PR TITLE
фикс двойных лор - выключена lora_to_extention()

### DIFF
--- a/src/3_installation.ipynb
+++ b/src/3_installation.ipynb
@@ -1285,7 +1285,7 @@
         "        configs()\n",
         "        eng_lang()\n",
         "        misc_dep_install()\n",
-        "        lora_to_extention()\n",
+        "        #lora_to_extention()\n",
         "        customisation()\n",
         "        cleanup()\n",
         "        complite()\n",


### PR DESCRIPTION
Стала не нужной после вписывания пути в конфигах.